### PR TITLE
Update Serkyu prompt for composite object breakdown

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -44,6 +44,21 @@ For composite concepts (e.g., 'blue elephant'):
   "explanation": "blue elephant as composite of primitives"
 }
 
+When a request describes an object with several distinct sections, break the design down into clearly named components so each part can be modeled individually. For example, a "toy robot" could be expressed as:
+{
+  "model": {
+    "type": "composite",
+    "components": [
+      { "name": "head", "primitive": "box", "scale": 0.4, "color": "#ffcc00", "offset": [0,0.8,0] },
+      { "name": "body", "primitive": "box", "scale": 0.6, "color": "#6699ff", "offset": [0,0,0] },
+      { "name": "arm_left", "primitive": "cylinder", "scale": 0.3, "color": "#6699ff", "offset": [-0.5,0.1,0], "rotation": [0,0,1.57] },
+      { "name": "arm_right", "primitive": "cylinder", "scale": 0.3, "color": "#6699ff", "offset": [0.5,0.1,0], "rotation": [0,0,-1.57] },
+      { "name": "legs", "primitive": "box", "scale": 0.5, "color": "#ff6600", "offset": [0,-0.7,0] }
+    ]
+  },
+  "explanation": "toy robot built from primitives"
+}
+
 Only output valid JSON inside the code block. Do not include extra full HTML or unrelated long prose in these cases.
 
 If the user explicitly asks for a full application, demo, or code file (e.g., "give me a complete HTML file that shows X"), then produce a complete, working, self-contained HTML/JS/CSS implementation as previously specified (using CDN for libraries, etc.). Otherwise, when it's a design instruction, favor the structured JSON response as above.


### PR DESCRIPTION
## Summary
- update system prompt in `/app/api/chat/route.js` to explain how to break complex requests into named components
- show example composite object for a toy robot

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, @next/next/no-assign-module-variable, react/display-name)*

------
https://chatgpt.com/codex/tasks/task_e_688d6560b3ec83259f5cebccdff6c95d