### PR TITLE
Enable HF 3D generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+HF_API_TOKEN=your_huggingface_api_token

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your Hugging Face token:
+
+```bash
+HF_API_TOKEN=your_huggingface_api_token
+```
+
+This token is used by the `/api/generate3d` endpoint to authenticate requests to Hugging Face models.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/app/About/page.js
+++ b/app/About/page.js
@@ -127,7 +127,7 @@ const AboutPage = () => {
           machine-learning-powered tools that make complex technical concepts accessible 
           to everyone. We believe that technology should empower creativity and learning, 
           not create additional obstacles. By combining cutting-edge artificial intelligence 
-          with intuitive design, we're building solutions that adapt to each user's unique 
+          with intuitive design, we&apos;re building solutions that adapt to each user&apos;s unique
           learning style and pace. At the heart of our approach is human-centered support that complements our 
           technological capabilities. We understand that while AI can process information 
           and generate solutions at unprecedented speeds, the human element remains crucial 
@@ -139,7 +139,7 @@ const AboutPage = () => {
 
         {/* Emphatic Statement */}
         <EmphaticText>
-          Together, we're democratizing engineering education and fostering innovation.
+          Together, we&apos;re democratizing engineering education and fostering innovation.
         </EmphaticText>
 
         {/* Built By Section */}

--- a/app/api/generate3d/route.js
+++ b/app/api/generate3d/route.js
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  try {
+    const { prompt } = await request.json();
+
+    if (!prompt) {
+      return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
+    }
+
+    const token = process.env.HF_API_TOKEN;
+    if (!token) {
+      return NextResponse.json(
+        { error: "HF_API_TOKEN is not configured" },
+        { status: 500 }
+      );
+    }
+
+    // Step 1: generate an image from the prompt using a text-to-image model
+    const textToImage = await fetch(
+      "https://api-inference.huggingface.co/models/stabilityai/stable-diffusion-2-1",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ inputs: prompt }),
+      }
+    );
+
+    if (!textToImage.ok) {
+      const errorText = await textToImage.text();
+      return NextResponse.json(
+        { error: "Failed to generate image", details: errorText },
+        { status: 500 }
+      );
+    }
+
+    const imageBuffer = Buffer.from(await textToImage.arrayBuffer());
+
+    // Step 2: send the image to an image-to-3D model
+    const imageTo3D = await fetch(
+      "https://api-inference.huggingface.co/models/ashawkey/zero123-xl",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/octet-stream",
+        },
+        body: imageBuffer,
+      }
+    );
+
+    if (!imageTo3D.ok) {
+      const errorText = await imageTo3D.text();
+      return NextResponse.json(
+        { error: "Failed to generate 3D model", details: errorText },
+        { status: 500 }
+      );
+    }
+
+    const modelBuffer = Buffer.from(await imageTo3D.arrayBuffer());
+    const contentType = imageTo3D.headers.get("content-type") ||
+      "application/octet-stream";
+
+    return new NextResponse(modelBuffer, {
+      status: 200,
+      headers: { "Content-Type": contentType },
+    });
+  } catch (err) {
+    console.error("Error in generate3d API:", err);
+    return NextResponse.json(
+      { error: "An error occurred while processing your request." },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- escape apostrophes in About page text
- fix variable naming for STLExporter dynamic import
- give ThreeDViewport a display name
- add option to generate a 3D file using the new `/api/generate3d` route

## Testing
- `npm run lint`
- `npm run build` *(fails: GROQ_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d66bb22e88325a8ac8497c4a3bb8f