### PR TITLE
refine prompt via chat before 3d generation

### DIFF
--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -3,9 +3,18 @@ import Groq from "groq-sdk";
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
+const defaultSystemPrompt = `You are Serkyu, a helpful assistant for interactive 3D design.
+You refine user requests into succinct prompts for a text-to-3D generator and offer friendly conversational feedback.
+When asked to refine a request, respond only with a JSON block of the form:
+{
+  "prompt": "refined prompt",
+  "message": "brief acknowledgement"
+}
+Otherwise, reply conversationally.`;
+
 export async function POST(request) {
   try {
-    const { message, history, systemPrompt } = await request.json();
+    const { message, history = [], systemPrompt } = await request.json();
 
     if (!message) {
       return NextResponse.json(
@@ -14,69 +23,12 @@ export async function POST(request) {
       );
     }
 
-    // System prompt: default to Serkyu capability but steer 3D object requests into structured output
-    const serkyuSystemPrompt = `You are Serkyu, a powerful assistant for interactive 3D design and code generation.
-
-When the user request pertains to creating or modifying a 3D object (e.g., "orange sphere", "blue elephant", etc.), you must respond with:
-1. A concise human-friendly acknowledgement sentence (no full HTML dumps).
-2. A JSON object inside a \`\`\`json block\`\`\` describing the desired model. Follow this schema strictly:
-
-For simple shapes:
-{
-  "model": {
-    "type": "primitive",
-    "primitive": "sphere" | "box" | "cylinder",
-    "scale": number,
-    "color": "#rrggbb"
-  },
-  "explanation": "short explanation"
-}
-
-For composite concepts (e.g., 'blue elephant'):
-{
-  "model": {
-    "type": "composite",
-    "components": [
-      { "name": "body", "primitive": "sphere", "scale": 1.2, "color": "#4c7bff", "offset": [0,0,0] },
-      { "name": "trunk", "primitive": "cylinder", "scale": 0.5, "color": "#4c7bff", "offset": [0.5,-0.2,0], "rotation": [1.57,0,0] }
-    ]
-  },
-  "explanation": "blue elephant as composite of primitives"
-}
-
-When a request describes an object with several distinct sections, break the design down into clearly named components so each part can be modeled individually. For example, a "toy robot" could be expressed as:
-{
-  "model": {
-    "type": "composite",
-    "components": [
-      { "name": "head", "primitive": "box", "scale": 0.4, "color": "#ffcc00", "offset": [0,0.8,0] },
-      { "name": "body", "primitive": "box", "scale": 0.6, "color": "#6699ff", "offset": [0,0,0] },
-      { "name": "arm_left", "primitive": "cylinder", "scale": 0.3, "color": "#6699ff", "offset": [-0.5,0.1,0], "rotation": [0,0,1.57] },
-      { "name": "arm_right", "primitive": "cylinder", "scale": 0.3, "color": "#6699ff", "offset": [0.5,0.1,0], "rotation": [0,0,-1.57] },
-      { "name": "legs", "primitive": "box", "scale": 0.5, "color": "#ff6600", "offset": [0,-0.7,0] }
-    ]
-  },
-  "explanation": "toy robot built from primitives"
-}
-
-Only output valid JSON inside the code block. Do not include extra full HTML or unrelated long prose in these cases.
-
-If the user explicitly asks for a full application, demo, or code file (e.g., "give me a complete HTML file that shows X"), then produce a complete, working, self-contained HTML/JS/CSS implementation as previously specified (using CDN for libraries, etc.). Otherwise, when it's a design instruction, favor the structured JSON response as above.
-
-CORE CAPABILITIES:
-- Three.js 3D visualizations
-- Interactive web apps
-- Clean, concise model specifications when appropriate
-
-When generating full code, obey best practices: responsive design, error handling, modern JS, and clarity.`;
-
-    // Build conversation history
     const messages = [
-      { role: "system", content: systemPrompt || serkyuSystemPrompt },
-      ... (Array.isArray(history) ? history.map((msg) => ({
-          role: msg.sender === "user" ? "user" : "assistant",
-          content: msg.text,
-        })) : []),
+      { role: "system", content: systemPrompt || defaultSystemPrompt },
+      ...history.map((msg) => ({
+        role: msg.sender === "user" ? "user" : "assistant",
+        content: msg.text,
+      })),
       { role: "user", content: message },
     ];
 
@@ -86,7 +38,6 @@ When generating full code, obey best practices: responsive design, error handlin
       temperature: 0.8,
       max_tokens: 2048,
       top_p: 0.95,
-      stream: false,
     });
 
     const responseMessage =

--- a/app/api/generate3d/route.js
+++ b/app/api/generate3d/route.js
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 
 export async function POST(request) {
   try {
-    const { prompt } = await request.json();
+    // Accept a refined prompt from the chat endpoint
+    const { prompt: rawPrompt } = await request.json();
+    const prompt = rawPrompt?.trim();
 
     if (!prompt) {
       return NextResponse.json({ error: "Prompt is required" }, { status: 400 });


### PR DESCRIPTION
## Summary
- streamline chat API with a default system prompt that refines user requests and gives friendly feedback
- allow generate3d endpoint to consume trimmed prompts from the chat step

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build` *(fails: GROQ_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d72673de8832592825b599ba7fb37