### PR TITLE
Improve 3D generation error handling

### DIFF
--- a/app/api/generate3d/route.js
+++ b/app/api/generate3d/route.js
@@ -72,9 +72,7 @@ export async function POST(request) {
     });
   } catch (err) {
     console.error("Error in generate3d API:", err);
-    return NextResponse.json(
-      { error: "An error occurred while processing your request." },
-      { status: 500 }
-    );
+    const message = err?.message || "An error occurred while processing your request.";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- expose detailed backend errors from 3D generation API
- display server error messages in snackbar for initial and chat submissions
- surface server error details in 3D generation route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d77c9aebc83258406bf20bd0b22dc